### PR TITLE
Add protocol selection (http/https) to admin UI

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -18,6 +18,21 @@
             "lg": 4,
             "xl": 4
         },
+        "protocol": {
+            "type": "select",
+            "label": "protocol",
+            "newLine": true,
+            "options": [
+                { "value": "http", "label": "HTTP" },
+                { "value": "https", "label": "HTTPS" }
+            ],
+            "default": "http",
+            "xs": 12,
+            "sm": 12,
+            "md": 6,
+            "lg": 4,
+            "xl": 4
+        },
         "password": {
             "type": "password",
             "label": "password",

--- a/lib/rainbird.js
+++ b/lib/rainbird.js
@@ -278,7 +278,7 @@ RainbirdController.prototype.request = function (data, length, callback) {
     });
 
     const reqopts = {
-        url: `http://${this.server}/stick`,
+        url: `${this.protocol}://${this.server}/stick`,
         method: 'POST',
         agent: keepAliveAgent,
         headers: {

--- a/main.js
+++ b/main.js
@@ -143,6 +143,8 @@ function main() {
     ioBLib.setOrUpdateState('device.commands.stopIrrigation', 'Stop irrigation', false, '', 'boolean', 'button.stop');
 
     controller = new rainbird.RainbirdController(deviceIpAdress, devicePassword, adapter);
+    // Set protocol based on config (default http)
+    controller.protocol = adapter.config.protocol || 'http';
 
     pollStates();
 }


### PR DESCRIPTION
After a lot of debugging I created this PR to switch between http and https.

Background: Rainbird has introduced the IQ4 cloud and my Rainbird ESP-TM2 only works with the cloud anymore. So if you use the Rainbird 2.0 you're stuck.

To get it back working after a lot of debugging. First of all you have to block all traffic from your Rainbird to the IQ4 cloud and vice versa because of limitation to one connection of the LNK. But they also changed from HTTP to HTTPS for the local communication (thanks to pyrainbird for the hint)

- [ ] test done on my local ioBroker