### PR TITLE
Fixed default protocol handling (default to http) if configuration setting is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ as expected.
 <!--
 	Placeholder for the next version (at the beginning of the line):
     ### **WORK IN PROGRESS**
+- (mobster80) Fixed default protocol handling (default to http) if configuration setting is missing
 -->
 ### 2.1.1 (2026-05-10)
 - (copilot) Adapter requires node.js >= 22 now

--- a/main.js
+++ b/main.js
@@ -93,8 +93,6 @@ function startAdapter(options) {
             adapter.log.warn('[START] IP address not set');
         } else if (!adapter.config.password) {
             adapter.log.warn('[START] Password not set');
-        } else if (!adapter.config.protocol) {
-            adapter.log.warn('[START] Protocol not set');
         } else {
             adapter.log.info(`[START] Starting Rain Bird adapter V${adapterVersion}${patchVersion}`);
             adapter.setState('info.connection', true, true);
@@ -124,6 +122,10 @@ function main() {
     deviceIpAdress = adapter.config.ipaddress;
     devicePassword = adapter.config.password;
     deviceProtocol = adapter.config.protocol;
+    if (!deviceProtocol) {
+        adapter.log.info('[INFO] Communication protocol not set - defaulting to http');
+        deviceProtocol = 'http';
+    }
 
     pollingTime = adapter.config.pollinterval || 30000;
     if (pollingTime < 5000) {


### PR DESCRIPTION
As mentioned in the bug report of Feuersturm there was an error when updating to the new version. The new behaviour doesn't bring the adapter into a warn state if the protocol is missing but instead delivers an INFO log the there was no protocol configured. Per default http is then selected as the protocol.

Tested on my local ioBroker instance where I could also reproduce the bug.